### PR TITLE
Add log stream validation in integration test

### DIFF
--- a/packages/server/src/__tests__/integration/socketio-message-flow.test.ts
+++ b/packages/server/src/__tests__/integration/socketio-message-flow.test.ts
@@ -461,18 +461,22 @@ describe('Socket.IO End-to-End Message Flow', () => {
 
       // Generate a log entry and expect it to be streamed to the client
       const logReceived = new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('Timed out waiting for log stream message'));
-        }, 5000);
-  
-        client1.on('log_stream', (data) => {
+        const logStreamHandler = (data) => {
           try {
-            clearTimeout(timeout);
             expect(data.type).toBe('log_entry');
             expect(data.payload).toMatchObject({
               agentName: 'Test Agent',
               msg: 'Integration test log message',
             });
+            client1.off('log_stream', logStreamHandler);
+            resolve(data);
+          } catch (err) {
+            client1.off('log_stream', logStreamHandler);
+            reject(err);
+          }
+        };
+
+        client1.on('log_stream', logStreamHandler);
             resolve(data);
           } catch (err) {
             clearTimeout(timeout);

--- a/packages/server/src/__tests__/integration/socketio-message-flow.test.ts
+++ b/packages/server/src/__tests__/integration/socketio-message-flow.test.ts
@@ -461,8 +461,13 @@ describe('Socket.IO End-to-End Message Flow', () => {
 
       // Generate a log entry and expect it to be streamed to the client
       const logReceived = new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Timed out waiting for log stream message'));
+        }, 5000);
+  
         client1.on('log_stream', (data) => {
           try {
+            clearTimeout(timeout);
             expect(data.type).toBe('log_entry');
             expect(data.payload).toMatchObject({
               agentName: 'Test Agent',
@@ -470,6 +475,7 @@ describe('Socket.IO End-to-End Message Flow', () => {
             });
             resolve(data);
           } catch (err) {
+            clearTimeout(timeout);
             reject(err);
           }
         });


### PR DESCRIPTION
### **User description**
## Summary
- test `socketio-message-flow` log stream after updating filters

## Testing
- `bun test packages/server/src/__tests__/integration/socketio-message-flow.test.ts` *(fails: Failed query: insert into "server_agents"...)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecc82be083308ede81fee1f2d7ef


___

### **PR Type**
Tests


___

### **Description**
- Add log stream validation to integration test

- Import logger from core module

- Verify log emission after filter updates

- Test actual log streaming functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>socketio-message-flow.test.ts</strong><dd><code>Implement log stream validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/server/src/__tests__/integration/socketio-message-flow.test.ts

<li>Import <code>logger</code> from <code>@elizaos/core</code> module<br> <li> Add log stream validation test with promise-based verification<br> <li> Generate test log entry and verify it's streamed to client<br> <li> Replace TODO comment with actual log streaming test implementation


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/6/files#diff-aaa633ebdf093a0b4aaa46fc3219add1f911d634cc267b7c047c7b58319bcc0c">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a test case to verify that log streaming works correctly for subscribed clients, ensuring that log events are received with the expected structure and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->