### PR TITLE
Filter channel agents using registry

### DIFF
--- a/packages/server/src/__tests__/channel-agents-filter.test.ts
+++ b/packages/server/src/__tests__/channel-agents-filter.test.ts
@@ -22,7 +22,11 @@ describe('getChannelAgents filtering', () => {
     } as unknown as AgentServer;
 
     const router = createChannelsRouter(agents, serverInstance);
-    const handler = getHandler(router, '/central-channels/:channelId/agents');
+    // Define path constant at the top of the file
+    const CHANNEL_AGENTS_PATH = '/central-channels/:channelId/agents';
+
+    // Then use it consistently
+    const handler = getHandler(router, CHANNEL_AGENTS_PATH);
 
     const req: any = { params: { channelId: 'abc' } };
     const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };

--- a/packages/server/src/__tests__/channel-agents-filter.test.ts
+++ b/packages/server/src/__tests__/channel-agents-filter.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { UUID, IAgentRuntime } from '@elizaos/core';
+import { createChannelsRouter } from '../api/messaging/channels';
+import type { AgentServer } from '../index';
+
+function getHandler(router: any, path: string) {
+  const layer = router.stack.find((l: any) => l.route && l.route.path === path);
+  return layer.route.stack[0].handle;
+}
+
+describe('getChannelAgents filtering', () => {
+  it('returns only participants that are registered agents', async () => {
+    const registeredId = '11111111-1111-1111-1111-111111111111' as UUID;
+    const unregisteredId = '22222222-2222-2222-2222-222222222222' as UUID;
+
+    const runtime = { agentId: registeredId, character: { name: 'Test' } } as unknown as IAgentRuntime;
+    const agents = new Map<UUID, IAgentRuntime>();
+    agents.set(registeredId, runtime);
+
+    const serverInstance = {
+      getChannelParticipants: vi.fn().mockResolvedValue([registeredId, unregisteredId]),
+    } as unknown as AgentServer;
+
+    const router = createChannelsRouter(agents, serverInstance);
+    const handler = getHandler(router, '/central-channels/:channelId/agents');
+
+    const req: any = { params: { channelId: 'abc' } };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await handler(req, res);
+
+    expect(serverInstance.getChannelParticipants).toHaveBeenCalledWith('abc');
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: { channelId: 'abc', participants: [registeredId] },
+    });
+  });
+
+  it('returns empty array when no registered agents', async () => {
+    const runtime = { agentId: '33333333-3333-3333-3333-333333333333' as UUID, character: { name: 'Test' } } as unknown as IAgentRuntime;
+    const agents = new Map<UUID, IAgentRuntime>();
+    agents.set(runtime.agentId, runtime);
+
+    const serverInstance = {
+      getChannelParticipants: vi.fn().mockResolvedValue(['44444444-4444-4444-4444-444444444444' as UUID]),
+    } as unknown as AgentServer;
+
+    const router = createChannelsRouter(agents, serverInstance);
+    const handler = getHandler(router, '/central-channels/:channelId/agents');
+
+    const req: any = { params: { channelId: 'xyz' } };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: { channelId: 'xyz', participants: [] },
+    });
+  });
+});

--- a/packages/server/src/__tests__/channel-agents-filter.test.ts
+++ b/packages/server/src/__tests__/channel-agents-filter.test.ts
@@ -50,7 +50,7 @@ describe('getChannelAgents filtering', () => {
     } as unknown as AgentServer;
 
     const router = createChannelsRouter(agents, serverInstance);
-    const handler = getHandler(router, '/central-channels/:channelId/agents');
+    const handler = getHandler(router, CHANNEL_AGENTS_PATH);
 
     const req: any = { params: { channelId: 'xyz' } };
     const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };

--- a/packages/server/src/api/messaging/channels.ts
+++ b/packages/server/src/api/messaging/channels.ts
@@ -624,8 +624,9 @@ export function createChannelsRouter(
         // Get all participants
         const allParticipants = await serverInstance.getChannelParticipants(channelId);
 
-        // Cross-reference participants with the active agent registry
-        const agentParticipants = allParticipants.filter((id) => agents.has(id));
+// Cross-reference participants with the active agent registry
+// agents map contains all the active agents.
+const agentParticipants = allParticipants.filter((id) => agents.has(id));
 
         res.json({
           success: true,

--- a/packages/server/src/api/messaging/channels.ts
+++ b/packages/server/src/api/messaging/channels.ts
@@ -624,17 +624,14 @@ export function createChannelsRouter(
         // Get all participants
         const allParticipants = await serverInstance.getChannelParticipants(channelId);
 
-        // Filter for agents (this is a simplified approach - you might want to
-        // implement a more sophisticated way to distinguish agents from users)
-        // For now, we'll return all participants and let the client filter
-        // In a production system, you'd want to cross-reference with an agent registry
+        // Cross-reference participants with the active agent registry
+        const agentParticipants = allParticipants.filter((id) => agents.has(id));
 
         res.json({
           success: true,
           data: {
             channelId,
-            participants: allParticipants, // All participants (agents and users)
-            // TODO: Add agent-specific filtering when agent registry is available
+            participants: agentParticipants, // Only registered agents
           },
         });
       } catch (error) {


### PR DESCRIPTION
### **User description**
## Summary
- filter `/central-channels/:channelId/agents` results with agent registry
- add unit tests for channel agent filtering

## Testing
- `npx vitest run packages/server/src/__tests__/channel-agents-filter.test.ts` *(fails: Cannot find package '@elizaos/core')*

------
https://chatgpt.com/codex/tasks/task_e_6857ecc940208330876d3cf547a630f4


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Filter channel agents endpoint to return only registered agents

- Add comprehensive unit tests for agent filtering functionality

- Remove TODO comments and implement proper registry filtering


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>channel-agents-filter.test.ts</strong><dd><code>Add unit tests for channel agent filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/server/src/__tests__/channel-agents-filter.test.ts

<li>Add new test file with 61 lines of comprehensive test coverage<br> <li> Test filtering of registered vs unregistered agents<br> <li> Test empty results when no registered agents found<br> <li> Mock server instance and agent registry for isolated testing


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/7/files#diff-7b9e222d6f0f044f2047914793176c2e5b43fb8107348c6d864bd889b5892749">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>channels.ts</strong><dd><code>Implement agent registry filtering for channel endpoints</code>&nbsp; </dd></summary>
<hr>

packages/server/src/api/messaging/channels.ts

<li>Filter channel participants using agent registry (<code>agents.has(id)</code>)<br> <li> Remove TODO comment and implement proper filtering logic<br> <li> Return only registered agents instead of all participants


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/7/files#diff-66ad411a01c3b16ac8db2dffd2d6a45d33f980bc4be9e8b83962041a417c5a36">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The list of channel participants now only displays registered agents, filtering out unregistered users.

- **Tests**
  - Added new tests to verify that only registered agents are returned in the channel participants list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->