### PR TITLE
Dynamic voice provider lookup

### DIFF
--- a/packages/client/src/config/__tests__/voice-models.test.ts
+++ b/packages/client/src/config/__tests__/voice-models.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildProviderPluginMap,
+  getRequiredPluginForProvider,
+} from '../voice-models';
+import { PluginMetadata } from '../plugin-metadata';
+
+describe('voice provider resolution', () => {
+  const metadata: PluginMetadata[] = [
+    { name: '@elizaos/plugin-elevenlabs', categories: ['voice-provider:elevenlabs'] },
+    { name: '@elizaos/plugin-local-ai', categories: ['voice-provider:local'] },
+  ];
+
+  it('buildProviderPluginMap extracts provider mapping', () => {
+    const map = buildProviderPluginMap(metadata);
+    expect(map.elevenlabs).toBe('@elizaos/plugin-elevenlabs');
+    expect(map.local).toBe('@elizaos/plugin-local-ai');
+  });
+
+  it('getRequiredPluginForProvider resolves plugin from metadata', () => {
+    const plugin = getRequiredPluginForProvider('local', metadata);
+    expect(plugin).toBe('@elizaos/plugin-local-ai');
+  });
+});

--- a/packages/client/src/config/plugin-metadata.ts
+++ b/packages/client/src/config/plugin-metadata.ts
@@ -1,0 +1,35 @@
+export interface PluginMetadata {
+  name: string;
+  categories: string[];
+}
+
+export const installedPluginMetadata: PluginMetadata[] = [
+  {
+    name: '@elizaos/plugin-elevenlabs',
+    categories: ['voice-provider:elevenlabs'],
+  },
+  {
+    name: '@elizaos/plugin-local-ai',
+    categories: ['voice-provider:local'],
+  },
+  {
+    name: '@elizaos/plugin-openai',
+    categories: ['voice-provider:openai'],
+  },
+];
+
+export function buildProviderPluginMap(
+  metadata: PluginMetadata[] = installedPluginMetadata,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  const prefix = 'voice-provider:';
+  for (const { name, categories } of metadata) {
+    for (const cat of categories || []) {
+      if (cat.startsWith(prefix)) {
+        const provider = cat.slice(prefix.length);
+        map[provider] = name;
+      }
+    }
+  }
+  return map;
+}

--- a/packages/client/src/config/voice-models.ts
+++ b/packages/client/src/config/voice-models.ts
@@ -182,7 +182,13 @@ export const getRequiredPluginForProvider = (
   provider: string,
   metadata: PluginMetadata[] = installedPluginMetadata,
 ): string | undefined => {
-  const map = provider === undefined ? {} : buildProviderPluginMap(metadata);
+  // Use the pre-built map for the default case to avoid re-computation.
+  if (metadata === installedPluginMetadata) {
+    return providerPluginMap[provider];
+  }
+
+  // Build the map on-demand only for custom metadata.
+  const map = buildProviderPluginMap(metadata);
   return map[provider];
 };
 

--- a/packages/client/src/config/voice-models.ts
+++ b/packages/client/src/config/voice-models.ts
@@ -14,7 +14,10 @@ import {
 } from './plugin-metadata';
 
 // Build the provider to plugin map dynamically using plugin categories
-export const providerPluginMap = buildProviderPluginMap(installedPluginMetadata);
+export const providerPluginMap = { 
+  ...buildProviderPluginMap(installedPluginMetadata),
+  none: '' // No plugin needed for "No Voice" option
+};
 export { buildProviderPluginMap };
 
 // No voice option for agents that don't need speech capabilities

--- a/packages/client/src/config/voice-models.ts
+++ b/packages/client/src/config/voice-models.ts
@@ -7,16 +7,15 @@ export interface VoiceModel {
   features?: string[];
 }
 
-// TODO: ELI2-218 Refactor this to use plugin categories when available
-// This hardcoded mapping will be replaced with a more flexible approach
-// that leverages plugin category metadata once implemented
+import {
+  buildProviderPluginMap,
+  installedPluginMetadata,
+  type PluginMetadata,
+} from './plugin-metadata';
 
-export const providerPluginMap: Record<string, string> = {
-  elevenlabs: '@elizaos/plugin-elevenlabs',
-  local: '@elizaos/plugin-local-ai',
-  openai: '@elizaos/plugin-openai',
-  none: '', // No plugin needed for "No Voice" option
-};
+// Build the provider to plugin map dynamically using plugin categories
+export const providerPluginMap = buildProviderPluginMap(installedPluginMetadata);
+export { buildProviderPluginMap };
 
 // No voice option for agents that don't need speech capabilities
 export const noVoiceModel: VoiceModel[] = [{ value: 'none', label: 'No Voice', provider: 'none' }];
@@ -179,11 +178,16 @@ export const getVoiceModelByValue = (value: string): VoiceModel | undefined => {
   return getAllVoiceModels().find((model) => model.value === value);
 };
 
-export const getRequiredPluginForProvider = (provider: string): string | undefined => {
-  return providerPluginMap[provider];
+export const getRequiredPluginForProvider = (
+  provider: string,
+  metadata: PluginMetadata[] = installedPluginMetadata,
+): string | undefined => {
+  const map = provider === undefined ? {} : buildProviderPluginMap(metadata);
+  return map[provider];
 };
 
-export const getAllRequiredPlugins = (): string[] => {
-  // Filter out empty strings (for "none" provider)
-  return Object.values(providerPluginMap).filter(Boolean);
+export const getAllRequiredPlugins = (
+  metadata: PluginMetadata[] = installedPluginMetadata,
+): string[] => {
+  return Object.values(buildProviderPluginMap(metadata)).filter(Boolean);
 };

--- a/packages/docs/docs/changelog.md
+++ b/packages/docs/docs/changelog.md
@@ -15,6 +15,7 @@
 - Add post-processing support for character loading #3686
 - Submit update env for plugin viction #3701
 - ANTHROPIC_API_URL env #3711
+- Voice provider plugins are now resolved dynamically using plugin category metadata
 
 #### Fixes
 


### PR DESCRIPTION
### **User description**
## Summary
- add plugin metadata list with categories
- compute voice provider plugins from metadata
- document dynamic voice provider resolution
- test provider resolution logic

## Testing
- `bun test packages/client/src/config/__tests__/voice-models.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857ecccb4048330ad13c6730b510a3f


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hardcoded voice provider mapping with dynamic plugin resolution

- Add plugin metadata system with category-based provider lookup

- Implement voice provider resolution using plugin categories

- Add comprehensive tests for provider resolution logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice-models.test.ts</strong><dd><code>Add voice provider resolution tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/src/config/__tests__/voice-models.test.ts

<li>Add test suite for voice provider resolution functionality<br> <li> Test <code>buildProviderPluginMap</code> function with mock metadata<br> <li> Test <code>getRequiredPluginForProvider</code> function with provider lookup


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/9/files#diff-ad6895b5f1346e39d424579793d263c644059c5e63b88a75771be950dbb2fe68">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin-metadata.ts</strong><dd><code>Create plugin metadata system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/src/config/plugin-metadata.ts

<li>Define <code>PluginMetadata</code> interface with name and categories<br> <li> Add <code>installedPluginMetadata</code> array with voice provider plugins<br> <li> Implement <code>buildProviderPluginMap</code> function for dynamic mapping


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/9/files#diff-6b94edba779a3a9f6537e63e2e4439850c09981914329c6606ff08580fa2bf4e">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>voice-models.ts</strong><dd><code>Implement dynamic voice provider resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/src/config/voice-models.ts

<li>Replace hardcoded <code>providerPluginMap</code> with dynamic generation<br> <li> Update <code>getRequiredPluginForProvider</code> to use metadata parameter<br> <li> Modify <code>getAllRequiredPlugins</code> to accept metadata parameter<br> <li> Remove TODO comment about plugin categories implementation


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/9/files#diff-6fe9ba5d313b4cd6a7c087ef858f352ee373740ea768f161518b300ab60ab407">+18/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changelog.md</strong><dd><code>Update changelog with new feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/docs/changelog.md

- Add changelog entry for dynamic voice provider resolution feature


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/9/files#diff-498a4be96d668c8d9798bae44934697635925df9ad6f3eba478c26e17280c0f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Voice provider plugins are now resolved dynamically using plugin category metadata, improving flexibility and extensibility for voice integrations.

- **Documentation**
  - Updated changelog to reflect the new dynamic voice provider plugin resolution feature.

- **Tests**
  - Added unit tests to verify correct mapping and resolution of voice provider plugins based on metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->