### PR TITLE
Improve plugin type detection

### DIFF
--- a/packages/cli/src/utils/registry/schema.ts
+++ b/packages/cli/src/utils/registry/schema.ts
@@ -1,5 +1,7 @@
 // src/utils/registry/schema.ts
 import { z } from 'zod';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export const registrySchema = z.record(z.string(), z.string());
 
@@ -17,9 +19,62 @@ export type PluginType = 'adapter' | 'client' | 'plugin';
  * @param {string} name - The name of the plugin.
  * @returns {PluginType} The type of plugin ('adapter', 'client', or 'plugin').
  */
-export function getPluginType(name: string): PluginType {
-  if (/sql/.test(name)) return 'adapter';
-  if (/discord|twitter|telegram/.test(name)) return 'client';
+export function getPluginType(
+  pkgOrPathOrName: Record<string, any> | string
+): PluginType {
+  let pkg: Record<string, any> | undefined;
+
+  if (typeof pkgOrPathOrName === 'string') {
+    const pkgPath = path.join(pkgOrPathOrName, 'package.json');
+    try {
+      const content = fs.readFileSync(pkgPath, 'utf8');
+      pkg = JSON.parse(content);
+    } catch {
+      // treat string as package name only
+    }
+  } else {
+    pkg = pkgOrPathOrName;
+  }
+
+  if (pkg) {
+    const keywords = pkg.keywords || [];
+    const pkgType = pkg.packageType;
+    const agentType = pkg.agentConfig?.pluginType as string | undefined;
+
+    if (
+      pkgType === 'adapter' ||
+      keywords.includes('adapter') ||
+      agentType?.includes('adapter')
+    ) {
+      return 'adapter';
+    }
+
+    if (
+      pkgType === 'client' ||
+      keywords.includes('client') ||
+      agentType?.includes('client')
+    ) {
+      return 'client';
+    }
+
+    if (
+      pkgType === 'plugin' ||
+      keywords.includes('plugin') ||
+      agentType?.includes('plugin')
+    ) {
+      return 'plugin';
+    }
+
+    if (pkg.name) {
+      if (/sql/.test(pkg.name)) return 'adapter';
+      if (/discord|twitter|telegram/.test(pkg.name)) return 'client';
+    }
+  } else if (typeof pkgOrPathOrName === 'string') {
+    const name = pkgOrPathOrName;
+    if (/sql/.test(name)) return 'adapter';
+    if (/discord|twitter|telegram/.test(name)) return 'client';
+  }
+
   return 'plugin';
 }
 

--- a/packages/cli/tests/unit/utils/registry-schema.test.ts
+++ b/packages/cli/tests/unit/utils/registry-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'bun:test';
+import { getPluginType } from '../../../src/utils/registry/schema';
+
+const adapterPkg = {
+  name: '@elizaos/plugin-sql',
+  keywords: ['adapter', 'database'],
+};
+
+const clientPkg = {
+  name: '@elizaos/plugin-discord',
+  agentConfig: {
+    pluginType: 'elizaos:client:1.0.0',
+  },
+};
+
+const pluginPkg = {
+  name: '@elizaos/plugin-starter',
+  packageType: 'plugin',
+};
+
+describe('getPluginType', () => {
+  it('detects adapter via keywords', () => {
+    expect(getPluginType(adapterPkg)).toBe('adapter');
+  });
+
+  it('detects client via agentConfig', () => {
+    expect(getPluginType(clientPkg)).toBe('client');
+  });
+
+  it('detects plugin via packageType', () => {
+    expect(getPluginType(pluginPkg)).toBe('plugin');
+  });
+
+  it('falls back to name heuristics', () => {
+    expect(getPluginType('@elizaos/plugin-twitter')).toBe('client');
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary
- enhance plugin type detection to use package metadata when available
- add unit tests covering new detection rules

## Testing
- `bun test tests/unit/utils/registry-schema.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857ecd5dae483308f1334650575354e


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced plugin type detection to use package metadata

- Added support for keywords, packageType, and agentConfig fields

- Maintained backward compatibility with name-based heuristics

- Added comprehensive unit tests for new detection logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Enhanced plugin type detection with metadata support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/utils/registry/schema.ts

<li>Enhanced <code>getPluginType</code> function to accept package objects or file <br>paths<br> <li> Added metadata-based detection using keywords, packageType, and <br>agentConfig<br> <li> Maintained fallback to name-based heuristics for backward <br>compatibility<br> <li> Added file system operations to read package.json files


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/15/files#diff-3ecfafe3bb5dec7e0c61e93474f0018a058a674ed078550eb3a47cbf5757d91d">+58/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry-schema.test.ts</strong><dd><code>Added unit tests for plugin type detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/tests/unit/utils/registry-schema.test.ts

<li>Added comprehensive unit tests for <code>getPluginType</code> function<br> <li> Created test cases for adapter, client, and plugin detection<br> <li> Tested metadata-based detection and name-based fallbacks


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/15/files#diff-7c59285aa47e2b0232a75882e0a394c115faaf99451a01644aed2b7dc35a1782">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>