### PR TITLE
Add auto imports to CLI test generator

### DIFF
--- a/packages/cli/scripts/generate-unit-tests.ts
+++ b/packages/cli/scripts/generate-unit-tests.ts
@@ -81,9 +81,6 @@ async function generateTestContent(sourcePath: string, testPath: string): Promis
   }
 
   testContent += `\ndescribe('${basename(sourcePath).replace('.ts', '')}', () => {\n  beforeEach(() => {\n    mock.restore();\n  });\n\n  afterEach(() => {\n    mock.restore();\n  });\n`;
-  beforeEach(() => {
-    mock.restore();
-  });
 
   afterEach(() => {
     mock.restore();

--- a/packages/cli/scripts/generate-unit-tests.ts
+++ b/packages/cli/scripts/generate-unit-tests.ts
@@ -192,6 +192,7 @@ async function main() {
         created++;
       } else {
         console.error(`❌ Test failed to run for ${relative(process.cwd(), file.testPath)}`);
+        await unlink(file.testPath).catch(() => {}); // Clean up failed test file
         failed++;
       }
     } catch (error) {


### PR DESCRIPTION
### **User description**
## Summary
- auto-detect exports when generating tests
- inject import statements
- ensure new tests compile by running `bun test`

## Testing
- `bun test` *(fails: Cannot find module '../dist/index.js' from project-tee-starter tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecdb52948330b2a0dee1a528d5b5


___

### **PR Type**
Enhancement


___

### **Description**
- Auto-detect and inject import statements in generated tests

- Validate test compilation by running `bun test` after generation

- Fix relative import path calculation for test files

- Add proper error handling for failed test compilation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-unit-tests.ts</strong><dd><code>Auto-import and validate test generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/scripts/generate-unit-tests.ts

<li>Added automatic import detection and injection for exported functions, <br>classes, and constants<br> <li> Fixed relative import path calculation using <code>dirname</code> and <code>relative</code> <br>functions<br> <li> Added test validation by running <code>bun test</code> after each test file <br>generation<br> <li> Enhanced error reporting for failed test compilation


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/17/files#diff-dc7a1bbbcc00930053bb1dfb9f47ef6dcf1dfca8f9683e2eacc66bd1ee5b08a7">+19/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>