### PR TITLE
Improve Service lifecycle handling

### DIFF
--- a/packages/cli/src/server/services/message.ts
+++ b/packages/cli/src/server/services/message.ts
@@ -56,14 +56,13 @@ export class MessageBusService extends Service {
   }
 
   static async start(runtime: IAgentRuntime): Promise<Service> {
-    const service = new MessageBusService(runtime);
+    const service = (await super.start(runtime)) as MessageBusService;
     await service.connectToMessageBus();
     return service;
   }
 
   static async stop(runtime: IAgentRuntime): Promise<void> {
-    const service = new MessageBusService(runtime);
-    await service.stop();
+    await super.stop(runtime);
   }
 
   private connectToMessageBus() {

--- a/packages/core/src/__tests__/service-lifecycle.test.ts
+++ b/packages/core/src/__tests__/service-lifecycle.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, spyOn } from 'bun:test';
+import { Service } from '../types';
+import type { IAgentRuntime } from '../types';
+
+class TestService extends Service {
+  static serviceType = 'test-service';
+  capabilityDescription = 'test';
+  started = false;
+  stopped = false;
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+}
+
+describe('Service base lifecycle', () => {
+  const createRuntime = () => ({
+    getService: () => null,
+  }) as unknown as IAgentRuntime;
+
+  it('should instantiate and call instance start', async () => {
+    const runtime = createRuntime();
+    const service = await TestService.start(runtime);
+    expect(service).toBeInstanceOf(TestService);
+    expect((service as TestService).started).toBe(true);
+  });
+
+  it('should call instance stop via static stop', async () => {
+    const runtime = createRuntime();
+    const service = new TestService(runtime);
+    runtime.getService = () => service;
+    const stopSpy = spyOn(service, 'stop');
+    await TestService.stop(runtime);
+    expect(stopSpy).toHaveBeenCalled();
+  });
+
+  it('should resolve when stopping missing service', async () => {
+    const runtime = createRuntime();
+    await expect(TestService.stop(runtime)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/specs/v2/types.ts
+++ b/packages/core/src/specs/v2/types.ts
@@ -2432,13 +2432,28 @@ export abstract class Service {
   /** Service configuration */
   config?: { [key: string]: any };
 
-  /** Start service connection */
-  static async start(_runtime: IAgentRuntime): Promise<Service> {
-    throw new Error('Not implemented');
+  /**
+   * Start service connection by creating an instance and invoking its instance
+   * `start` method when available.
+   */
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new (this as any)(runtime) as Service & {
+      start?: () => Promise<void> | void;
+    };
+    if (typeof service.start === 'function') {
+      await service.start();
+    }
+    return service;
   }
 
-  /** Stop service connection */
-  static async stop(_runtime: IAgentRuntime): Promise<unknown> {
-    throw new Error('Not implemented');
+  /**
+   * Stop service connection by retrieving the instance from the runtime and
+   * calling its `stop` method.
+   */
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService(this.serviceType) as Service | null;
+    if (service) {
+      await service.stop();
+    }
   }
 }

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -127,14 +127,31 @@ export abstract class Service {
   /** Service configuration */
   config?: Metadata;
 
-  /** Start service connection */
-  static async start(_runtime: IAgentRuntime): Promise<Service> {
-    throw new Error('Not implemented');
+  /**
+   * Start service connection by creating an instance and invoking its instance
+   * `start` method when available. Subclasses can override this for custom
+   * behaviour but it provides sensible defaults for simple services.
+   */
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new (this as any)(runtime) as Service & {
+      start?: () => Promise<void> | void;
+    };
+    if (typeof service.start === 'function') {
+      await service.start();
+    }
+    return service;
   }
 
-  /** Stop service connection */
-  static async stop(_runtime: IAgentRuntime): Promise<unknown> {
-    throw new Error('Not implemented');
+  /**
+   * Stop service connection by retrieving the instance from the runtime and
+   * calling its `stop` method. Subclasses may override for specialised
+   * shutdown logic.
+   */
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService(this.serviceType) as Service | null;
+    if (service) {
+      await service.stop();
+    }
   }
 }
 

--- a/packages/plugin-bootstrap/src/services/task.ts
+++ b/packages/plugin-bootstrap/src/services/task.ts
@@ -44,7 +44,7 @@ export class TaskService extends Service {
    * @returns {Promise<Service>} A promise that resolves with the TaskService instance.
    */
   static async start(runtime: IAgentRuntime): Promise<Service> {
-    const service = new TaskService(runtime);
+    const service = (await super.start(runtime)) as TaskService;
     await service.startTimer();
     // await service.createTestTasks();
     return service;
@@ -293,10 +293,7 @@ export class TaskService extends Service {
    * @returns {Promise<void>} - A promise that resolves once the service has been stopped.
    */
   static async stop(runtime: IAgentRuntime) {
-    const service = runtime.getService(ServiceType.TASK);
-    if (service) {
-      await service.stop();
-    }
+    await super.stop(runtime);
   }
 
   /**

--- a/packages/plugin-dummy-services/src/lp/service.ts
+++ b/packages/plugin-dummy-services/src/lp/service.ts
@@ -14,15 +14,11 @@ export class DummyLpService extends ILpService {
   }
 
   static async start(runtime: IAgentRuntime): Promise<DummyLpService> {
-    const service = new DummyLpService(runtime);
-    return service;
+    return (await super.start(runtime)) as DummyLpService;
   }
 
   static async stop(runtime: IAgentRuntime): Promise<void> {
-    const service = runtime.getService<DummyLpService>(DummyLpService.serviceType);
-    if (service) {
-      await service.stop();
-    }
+    await super.stop(runtime);
   }
 
   async start(runtime: IAgentRuntime): Promise<void> {

--- a/packages/plugin-dummy-services/src/tokenData/service.ts
+++ b/packages/plugin-dummy-services/src/tokenData/service.ts
@@ -65,15 +65,11 @@ export class DummyTokenDataService extends Service implements ITokenDataService 
   }
 
   static async start(runtime: IAgentRuntime): Promise<DummyTokenDataService> {
-    const service = new DummyTokenDataService(runtime);
-    return service;
+    return (await super.start(runtime)) as DummyTokenDataService;
   }
 
   static async stop(runtime: IAgentRuntime): Promise<void> {
-    const service = runtime.getService<DummyTokenDataService>(DummyTokenDataService.serviceType);
-    if (service) {
-      await service.stop();
-    }
+    await super.stop(runtime);
   }
 
   async start(): Promise<void> {

--- a/packages/plugin-dummy-services/src/wallet/service.ts
+++ b/packages/plugin-dummy-services/src/wallet/service.ts
@@ -55,9 +55,7 @@ export class DummyWalletService extends Service implements IWalletService {
 
   public static async start(runtime: AgentRuntime): Promise<DummyWalletService> {
     console.log(`[${DummyWalletService.serviceType}] static start called - creating instance.`);
-    const instance = new DummyWalletService(runtime);
-    // No further async init in instance.start() currently needed for this simple map-based wallet
-    return instance;
+    return (await super.start(runtime)) as DummyWalletService;
   }
 
   public async start(): Promise<void> {

--- a/packages/plugin-starter/src/__tests__/plugin.test.ts
+++ b/packages/plugin-starter/src/__tests__/plugin.test.ts
@@ -166,17 +166,14 @@ describe('StarterService', () => {
     expect(stopSpy).toHaveBeenCalled();
   });
 
-  it('should throw an error when stopping a non-existent service', async () => {
+  it('should handle stopping a non-existent service gracefully', async () => {
     const runtime = createRealRuntime();
-    // Don't register a service, so getService will return null
-
-    // We'll patch the getService function to ensure it returns null
+    // Ensure getService returns null
     const originalGetService = runtime.getService;
     runtime.getService = () => null;
 
-    await expect(StarterService.stop(runtime as any)).rejects.toThrow('Starter service not found');
+    await expect(StarterService.stop(runtime as any)).resolves.toBeUndefined();
 
-    // Restore original getService function
     runtime.getService = originalGetService;
   });
 });

--- a/packages/plugin-starter/src/index.ts
+++ b/packages/plugin-starter/src/index.ts
@@ -142,18 +142,12 @@ export class StarterService extends Service {
 
   static async start(runtime: IAgentRuntime) {
     logger.info(`*** Starting starter service - MODIFIED: ${new Date().toISOString()} ***`);
-    const service = new StarterService(runtime);
-    return service;
+    return (await super.start(runtime)) as StarterService;
   }
 
   static async stop(runtime: IAgentRuntime) {
     logger.info('*** TESTING DEV MODE - STOP MESSAGE CHANGED! ***');
-    // get the service from the runtime
-    const service = runtime.getService(StarterService.serviceType);
-    if (!service) {
-      throw new Error('Starter service not found');
-    }
-    service.stop();
+    await super.stop(runtime);
   }
 
   async stop() {

--- a/packages/project-starter/src/__tests__/error-handling.test.ts
+++ b/packages/project-starter/src/__tests__/error-handling.test.ts
@@ -78,20 +78,13 @@ describe('Error Handling', () => {
   });
 
   describe('Service Error Handling', () => {
-    it('should throw an error when stopping non-existent service', async () => {
+    it('should handle stopping non-existent service gracefully', async () => {
       const mockRuntime = {
         getService: spyOnfn().mockReturnValue(null),
       } as unknown as IAgentRuntime;
 
-      let caughtError = null;
-      try {
-        await StarterService.stop(mockRuntime);
-      } catch (error: any) {
-        caughtError = error;
-        expect(error.message).toBe('Starter service not found');
-      }
+      await expect(StarterService.stop(mockRuntime)).resolves.toBeUndefined();
 
-      expect(caughtError).not.toBeNull();
       expect(mockRuntime.getService).toHaveBeenCalledWith('starter');
     });
 

--- a/packages/project-starter/src/__tests__/plugin.test.ts
+++ b/packages/project-starter/src/__tests__/plugin.test.ts
@@ -328,37 +328,17 @@ describe('StarterService', () => {
     );
   });
 
-  it('should throw an error when stopping a non-existent service', async () => {
+  it('should handle stopping a non-existent service gracefully', async () => {
     const runtime = createRealRuntime();
-    // Don't register a service, so getService will return null
 
-    let error: Error | null = null;
+    const originalGetService = runtime.getService;
+    runtime.getService = () => null;
 
-    try {
-      // We'll patch the getService function to ensure it returns null
-      const originalGetService = runtime.getService;
-      runtime.getService = () => null;
+    await expect(StarterService.stop(runtime as any)).resolves.toBeUndefined();
 
-      await StarterService.stop(runtime as any);
-      // Should not reach here
-      expect(true).toBe(false);
-    } catch (e) {
-      error = e as Error;
-      // This is expected - verify it's the right error
-      expect(error).toBeTruthy();
-      if (error instanceof Error) {
-        expect(error.message).toContain('Starter service not found');
-      }
-    }
+    documentTestResult('StarterService non-existent stop', { success: true });
 
-    documentTestResult(
-      'StarterService non-existent stop',
-      {
-        errorThrown: !!error,
-        errorMessage: error?.message || 'No error message',
-      },
-      error
-    );
+    runtime.getService = originalGetService;
   });
 
   it('should stop a registered service', async () => {

--- a/packages/project-starter/src/plugin.ts
+++ b/packages/project-starter/src/plugin.ts
@@ -138,18 +138,12 @@ export class StarterService extends Service {
 
   static async start(runtime: IAgentRuntime) {
     logger.info('*** Starting starter service ***');
-    const service = new StarterService(runtime);
-    return service;
+    return (await super.start(runtime)) as StarterService;
   }
 
   static async stop(runtime: IAgentRuntime) {
     logger.info('*** Stopping starter service ***');
-    // get the service from the runtime
-    const service = runtime.getService(StarterService.serviceType);
-    if (!service) {
-      throw new Error('Starter service not found');
-    }
-    service.stop();
+    await super.stop(runtime);
   }
 
   async stop() {

--- a/packages/project-tee-starter/src/plugin.ts
+++ b/packages/project-tee-starter/src/plugin.ts
@@ -41,7 +41,7 @@ export class StarterService extends Service {
 
   static async start(runtime: IAgentRuntime) {
     logger.info("*** Starting Mr. TEE's custom service (StarterService) ***");
-    const service = new StarterService(runtime);
+    const service = (await super.start(runtime)) as StarterService;
     try {
       const deriveKeyResponse: DeriveKeyResponse = await service.teeClient.deriveKey(
         service.secretSalt
@@ -79,11 +79,7 @@ export class StarterService extends Service {
 
   static async stop(runtime: IAgentRuntime) {
     logger.info("*** Stopping Mr. TEE's custom service (StarterService) ***");
-    const service = runtime.getService(StarterService.serviceType);
-    if (!service) {
-      throw new Error('Mr. TEE custom service (StarterService) not found');
-    }
-    service.stop();
+    await super.stop(runtime);
   }
 
   async stop() {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -49,14 +49,13 @@ export class MessageBusService extends Service {
   }
 
   static async start(runtime: IAgentRuntime): Promise<Service> {
-    const service = new MessageBusService(runtime);
+    const service = (await super.start(runtime)) as MessageBusService;
     await service.connectToMessageBus();
     return service;
   }
 
   static async stop(runtime: IAgentRuntime): Promise<void> {
-    const service = new MessageBusService(runtime);
-    await service.stop();
+    await super.stop(runtime);
   }
 
   private async connectToMessageBus() {


### PR DESCRIPTION
## Summary
- add default start/stop implementations to `Service`
- update spec version of Service
- rely on base lifecycle in derived services
- adjust plugin tests for new behaviour
- add unit test covering Service lifecycle

## Testing
- `bun test packages/core/src/__tests__/service-lifecycle.test.ts`
- `bun test packages/core/src/__tests__/services.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857ece38f548330964debaa2005e01c