### PR TITLE
Filter agents in channels list

### DIFF
--- a/packages/server/src/__tests__/channels-agents-route.test.ts
+++ b/packages/server/src/__tests__/channels-agents-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, jest } from 'bun:test';
+import { createChannelsRouter } from '../api/messaging/channels';
+import { createMockAgentRuntime } from './test-utils/mocks';
+import express from 'express';
+
+describe('channels router - list agents', () => {
+  let router: express.Router;
+  let mockServer: any;
+
+  beforeEach(() => {
+    mockServer = {
+      getChannelParticipants: jest.fn(),
+    } as any;
+  });
+
+  function getHandler(r: express.Router) {
+    const layer = r.stack.find(
+      (l: any) =>
+        l.route &&
+        l.route.path === '/central-channels/:channelId/agents' &&
+        l.route.methods.get
+    );
+    return layer.route.stack[0].handle;
+  }
+
+  it('returns all participants when registry empty', async () => {
+    const agents = new Map<string, any>();
+    const participants = ['a', 'b'];
+    mockServer.getChannelParticipants.mockResolvedValue(participants);
+    router = createChannelsRouter(agents, mockServer);
+    const handler = getHandler(router);
+
+    const req = { params: { channelId: '123e4567-e89b-12d3-a456-426614174000' } } as express.Request;
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() } as any;
+
+    await handler(req, res);
+    expect(res.json.mock.calls[0][0]).toEqual({
+      success: true,
+      data: {
+        channelId: '123e4567-e89b-12d3-a456-426614174000',
+        participants,
+        agents: participants,
+      },
+    });
+  });
+
+  it('filters participants when registry has agents', async () => {
+    const runtime = createMockAgentRuntime();
+    const agents = new Map<string, any>([[runtime.agentId, runtime]]);
+    const participants = [runtime.agentId, 'user'];
+    mockServer.getChannelParticipants.mockResolvedValue(participants);
+    router = createChannelsRouter(agents, mockServer);
+    const handler = getHandler(router);
+
+    const req = { params: { channelId: '123e4567-e89b-12d3-a456-426614174000' } } as express.Request;
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() } as any;
+
+    await handler(req, res);
+    expect(res.json.mock.calls[0][0]).toEqual({
+      success: true,
+      data: {
+        channelId: '123e4567-e89b-12d3-a456-426614174000',
+        participants,
+        agents: [runtime.agentId],
+      },
+    });
+  });
+});

--- a/packages/server/src/api/messaging/channels.ts
+++ b/packages/server/src/api/messaging/channels.ts
@@ -624,17 +624,18 @@ export function createChannelsRouter(
         // Get all participants
         const allParticipants = await serverInstance.getChannelParticipants(channelId);
 
-        // Filter for agents (this is a simplified approach - you might want to
-        // implement a more sophisticated way to distinguish agents from users)
-        // For now, we'll return all participants and let the client filter
-        // In a production system, you'd want to cross-reference with an agent registry
+        // Determine agent participants if registry is available
+        const agentParticipants =
+          agents && agents.size > 0
+            ? allParticipants.filter((id) => agents.has(id))
+            : allParticipants;
 
         res.json({
           success: true,
           data: {
             channelId,
-            participants: allParticipants, // All participants (agents and users)
-            // TODO: Add agent-specific filtering when agent registry is available
+            participants: allParticipants,
+            agents: agentParticipants,
           },
         });
       } catch (error) {


### PR DESCRIPTION
### **User description**
## Summary
- filter channel participants to return only active agent ids
- test agent filtering behavior in channels router

## Testing
- `bun test packages/server/src/__tests__/channels-agents-route.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857ecefa2a48330b59918a51dea226c


___

### **PR Type**
Enhancement


___

### **Description**
- Filter channel participants to return only active agent IDs

- Add agent registry-based filtering logic in channels router

- Create comprehensive tests for agent filtering behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>channels-agents-route.test.ts</strong><dd><code>Add comprehensive agent filtering tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/server/src/__tests__/channels-agents-route.test.ts

<li>Add new test file for channels router agent filtering<br> <li> Test empty registry returns all participants as agents<br> <li> Test populated registry filters only registered agents<br> <li> Mock server and agent runtime for testing scenarios


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/22/files#diff-cbfb877c41ea725de4d32d76e3d57027a88115acdc64ea7a503caafa8dcd16e2">+68/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>channels.ts</strong><dd><code>Implement agent registry-based participant filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/server/src/api/messaging/channels.ts

<li>Replace TODO comment with actual agent filtering logic<br> <li> Filter participants using agent registry when available<br> <li> Return filtered agents list in response data<br> <li> Fallback to all participants when registry is empty


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/22/files#diff-66ad411a01c3b16ac8db2dffd2d6a45d33f980bc4be9e8b83962041a417c5a36">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>