### PR TITLE
Add optional auth headers to message bus

### DIFF
--- a/packages/cli/src/server/services/message.ts
+++ b/packages/cli/src/server/services/message.ts
@@ -524,7 +524,7 @@ export class MessageBusService extends Service {
       const serverApiUrl = `${baseUrl}/api/messaging/submit`;
       const response = await fetch(serverApiUrl, {
         method: 'POST',
-        headers: this.getAuthHeaders(),
+        headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
         body: JSON.stringify(payloadToServer),
       });
 

--- a/packages/cli/src/server/services/message.ts
+++ b/packages/cli/src/server/services/message.ts
@@ -87,7 +87,8 @@ export class MessageBusService extends Service {
         return [];
       }
       const response = await fetch(
-        `${serverApiUrl}/api/messaging/central-channels/${channelId}/participants`
+        `${serverApiUrl}/api/messaging/central-channels/${channelId}/participants`,
+        { headers: this.getAuthHeaders() }
       );
 
       if (response.ok) {
@@ -110,7 +111,8 @@ export class MessageBusService extends Service {
     try {
       const serverApiUrl = this.getCentralMessageServerUrl();
       const response = await fetch(
-        `${serverApiUrl}/api/messaging/agents/${this.runtime.agentId}/servers`
+        `${serverApiUrl}/api/messaging/agents/${this.runtime.agentId}/servers`,
+        { headers: this.getAuthHeaders() }
       );
 
       if (response.ok) {
@@ -522,7 +524,7 @@ export class MessageBusService extends Service {
       const serverApiUrl = `${baseUrl}/api/messaging/submit`;
       const response = await fetch(serverApiUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' /* TODO: Add Auth if needed */ },
+        headers: this.getAuthHeaders(),
         body: JSON.stringify(payloadToServer),
       });
 
@@ -537,6 +539,19 @@ export class MessageBusService extends Service {
         error
       );
     }
+  }
+
+  private getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    const token =
+      (this.runtime.getSetting?.('ELIZA_SERVER_AUTH_TOKEN') as string | undefined) ??
+      process.env.ELIZA_SERVER_AUTH_TOKEN;
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return headers;
   }
 
   getCentralMessageServerUrl(): string {

--- a/packages/cli/src/server/services/message.ts
+++ b/packages/cli/src/server/services/message.ts
@@ -542,7 +542,7 @@ export class MessageBusService extends Service {
   }
 
   private getAuthHeaders(): Record<string, string> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {};
 
     const token =
       (this.runtime.getSetting?.('ELIZA_SERVER_AUTH_TOKEN') as string | undefined) ??

--- a/packages/cli/tests/unit/services/message-service.test.ts
+++ b/packages/cli/tests/unit/services/message-service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { MessageBusService } from '../../../src/server/services/message';
+import type { IAgentRuntime, Character, UUID } from '@elizaos/core';
+
+// Mock logger to silence output
+mock.module('@elizaos/core', async () => {
+  const actual = await import('@elizaos/core');
+  return {
+    ...actual,
+    logger: { info: mock(), debug: mock(), warn: mock(), error: mock() },
+  };
+});
+
+const mockFetch = mock(async () => ({
+  ok: true,
+  json: async () => ({ success: true, data: { servers: [] } }),
+})) as any;
+(global as any).fetch = mockFetch;
+
+function createRuntime(token?: string): IAgentRuntime {
+  const runtime: Partial<IAgentRuntime> = {
+    agentId: '123e4567-e89b-12d3-a456-426614174000' as UUID,
+    character: {
+      id: 'char-id' as UUID,
+      name: 'Tester',
+      description: '',
+      bio: [],
+      system: '',
+      modelProvider: '',
+      settings: {} as any,
+    } as Character,
+    getSetting: mock(() => token ?? null),
+  };
+  return runtime as IAgentRuntime;
+}
+
+describe('MessageBusService auth headers', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('includes Authorization header when token is in runtime settings', async () => {
+    const runtime = createRuntime('runtime-token');
+    const service = new MessageBusService(runtime);
+    await (service as any).fetchAgentServers();
+    const options = mockFetch.mock.calls[0][1];
+    expect(options.headers).toEqual(
+      expect.objectContaining({ Authorization: 'Bearer runtime-token' })
+    );
+  });
+
+  it('includes Authorization header when token is in env', async () => {
+    const runtime = createRuntime();
+    process.env.ELIZA_SERVER_AUTH_TOKEN = 'env-token';
+    const service = new MessageBusService(runtime);
+    await (service as any).fetchAgentServers();
+    const options = mockFetch.mock.calls[0][1];
+    expect(options.headers).toEqual(
+      expect.objectContaining({ Authorization: 'Bearer env-token' })
+    );
+    delete process.env.ELIZA_SERVER_AUTH_TOKEN;
+  });
+
+  it('omits Authorization header when no token', async () => {
+    const runtime = createRuntime();
+    const service = new MessageBusService(runtime);
+    await (service as any).fetchAgentServers();
+    const options = mockFetch.mock.calls[0][1];
+    expect((options.headers as any).Authorization).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/unit/services/message-service.test.ts
+++ b/packages/cli/tests/unit/services/message-service.test.ts
@@ -11,11 +11,17 @@ mock.module('@elizaos/core', async () => {
   };
 });
 
+const originalFetch = global.fetch;
 const mockFetch = mock(async () => ({
   ok: true,
   json: async () => ({ success: true, data: { servers: [] } }),
 })) as any;
 (global as any).fetch = mockFetch;
+
+// Add in afterAll or similar:
+// afterAll(() => {
+//   (global as any).fetch = originalFetch;
+// });
 
 function createRuntime(token?: string): IAgentRuntime {
   const runtime: Partial<IAgentRuntime> = {


### PR DESCRIPTION
### **User description**
## Summary
- add support for bearer auth headers when communicating with the central message server
- read token from runtime setting or `ELIZA_SERVER_AUTH_TOKEN` env
- include new tests for header injection

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecf00bb08330947a210be1e751a4


___

### **PR Type**
Enhancement


___

### **Description**
- Add Bearer token authentication support to message bus service

- Include auth headers in all central server API calls

- Support token from runtime settings or environment variable

- Add comprehensive unit tests for auth header functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message.ts</strong><dd><code>Implement Bearer token authentication for API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/server/services/message.ts

<li>Add <code>getAuthHeaders()</code> method to generate auth headers with Bearer token<br> <li> Update three fetch calls to include auth headers: <br><code>getChannelParticipants</code>, <code>fetchAgentServers</code>, and message submission<br> <li> Support token from runtime setting <code>ELIZA_SERVER_AUTH_TOKEN</code> or <br>environment variable<br> <li> Replace hardcoded Content-Type header with centralized header <br>management


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/23/files#diff-d23bc28ca55b1ade0d388774f8ae336bca84c1942514f000ffbfc6a94d94f866">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message-service.test.ts</strong><dd><code>Add unit tests for auth header functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/tests/unit/services/message-service.test.ts

<li>Create comprehensive test suite for auth header functionality<br> <li> Test token from runtime settings, environment variable, and no token <br>scenarios<br> <li> Mock fetch and logger dependencies for isolated testing<br> <li> Verify Authorization header presence and format in API calls


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/eliza/pull/23/files#diff-7aa4a04f5ddce1e3c4587f219c99c87c9e28ace52bdc357a2e87d7d7403ecc0a">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>